### PR TITLE
mark password field as sensitive in scram user credentials

### DIFF
--- a/kafka/resource_kafka_user_scram_credential.go
+++ b/kafka/resource_kafka_user_scram_credential.go
@@ -49,6 +49,7 @@ func kafkaUserScramCredentialResource() *schema.Resource {
 				ForceNew:    false,
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 				Description: "The password of the credential",
+				Sensitive: true,
 			},
 		},
 	}


### PR DESCRIPTION
Mark password as sensitive field while creating the scram user. This will prevent logging user passwords in plan output.